### PR TITLE
Re-authenticate if token lookup fails

### DIFF
--- a/pkg/vault/lease.go
+++ b/pkg/vault/lease.go
@@ -22,7 +22,13 @@ func (c *Client) LeaseRefresher(ctx context.Context, interval time.Duration) {
 		case <-ticker.C:
 			token, err := c.Auth().Token().LookupSelf()
 			if err != nil {
-				zap.L().Error("failed to lookup token", zap.Error(err))
+				zap.L().Error("failed to lookup token, performing new authentication", zap.Error(err))
+
+				if authErr := c.AuthMethodFunc(c); authErr != nil {
+					zap.L().Error("failed to authenticate", zap.Error(authErr))
+				} else {
+					zap.L().Info("successfully re-authenticated")
+				}
 
 				continue
 			}

--- a/pkg/vault/lease.go
+++ b/pkg/vault/lease.go
@@ -2,12 +2,29 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"encoding/json"
 	"time"
 
 	"github.com/FalcoSuessgott/vault-kubernetes-kms/pkg/metrics"
+	"github.com/hashicorp/vault/api"
 	"go.uber.org/zap"
 )
+
+func isAuthError(err error) bool {
+	var respErr *api.ResponseError
+	return errors.As(err, &respErr) &&
+		(respErr.StatusCode == 401 || respErr.StatusCode == 403)
+}
+
+func authenticateAndVerify(c *Client) error {
+	if err := c.AuthMethodFunc(c); err != nil {
+		return err
+	}
+
+	_, err := c.Auth().Token().LookupSelf()
+	return err
+}
 
 // LeaseRefresher periodically checks the ttl of the current lease and attempts to renew it if the ttl is less than half of the creation ttl.
 // if the token renewal fails, a new login with the configured auth method is performed
@@ -22,14 +39,19 @@ func (c *Client) LeaseRefresher(ctx context.Context, interval time.Duration) {
 		case <-ticker.C:
 			token, err := c.Auth().Token().LookupSelf()
 			if err != nil {
-				zap.L().Error("failed to lookup token, performing new authentication", zap.Error(err))
+				if isAuthError(err) {
+					zap.L().Error("failed to lookup token, performing new authentication", zap.Error(err))
 
-				if authErr := c.AuthMethodFunc(c); authErr != nil {
-					zap.L().Error("failed to authenticate", zap.Error(authErr))
-				} else {
-					zap.L().Info("successfully re-authenticated")
+					if authErr := authenticateAndVerify(c); authErr != nil {
+						zap.L().Error("failed to authenticate or verify token", zap.Error(authErr))
+					} else {
+						zap.L().Info("successfully re-authenticated")
+					}
+
+					continue
 				}
 
+				zap.L().Error("failed to lookup token", zap.Error(err))
 				continue
 			}
 

--- a/pkg/vault/lease_test.go
+++ b/pkg/vault/lease_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"strings"
 	"time"
 )
 
@@ -28,5 +29,55 @@ func (s *VaultSuite) TestTokenRefresher() {
 
 		_, err = s.tc.RunCommand("vault token lookup " + token)
 		s.Require().NoError(err, "token lookup")
+	})
+}
+
+func (s *VaultSuite) TestTokenRefresherReauthenticatesOnLookupFailure() {
+	s.Run("reauthenticates after token lookup failure", func() {
+		const (
+			mount = "approle-lease-test"
+			role  = "lease-reauth-test"
+		)
+
+		_, err := s.tc.RunCommand("vault auth enable -path=" + mount + " approle")
+		s.Require().NoError(err)
+
+		_, err = s.tc.RunCommand(
+			"vault write auth/" + mount + "/role/" + role +
+				" token_policies=default token_ttl=1h token_max_ttl=4h",
+		)
+		s.Require().NoError(err)
+
+		roleID, err := s.tc.RunCommand(
+			"vault read -field=role_id auth/" + mount + "/role/" + role + "/role-id",
+		)
+		s.Require().NoError(err)
+
+		secretID, err := s.tc.RunCommand(
+			"vault write -f -field=secret_id auth/" + mount + "/role/" + role + "/secret-id",
+		)
+		s.Require().NoError(err)
+
+		vc, err := NewClient(
+			WithVaultAddress(s.tc.URI),
+			WithAppRoleAuth(mount, strings.TrimSpace(roleID), strings.TrimSpace(secretID)),
+		)
+		s.Require().NoError(err)
+
+		oldToken := vc.Client.Token()
+		s.Require().NotEmpty(oldToken)
+
+		_, err = s.tc.RunCommand("vault token revoke " + oldToken)
+		s.Require().NoError(err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		go vc.LeaseRefresher(ctx, 500*time.Millisecond)
+
+		s.Eventually(func() bool {
+			_, err := vc.Auth().Token().LookupSelf()
+			return err == nil && vc.Client.Token() != oldToken
+		}, 8*time.Second, 250*time.Millisecond)
 	})
 }


### PR DESCRIPTION
The fix re-authenticates if the token lookup fails. This may happen if the previous renewal was unsuccessful.

Runs stable for several days now.

```syslog
Mai 19 18:37:30 cp2 vault-kubernetes-kms[3537120]: {"level":"info","timestamp":"2026-05-19T18:37:30.314+0200","caller":"vault/lease.go:66","message":"checking token renewal","creation_ttl":3600,"ttl":1}
Mai 19 18:37:30 cp2 vault-kubernetes-kms[3537120]: {"level":"info","timestamp":"2026-05-19T18:37:30.314+0200","caller":"vault/lease.go:70","message":"attempting token renewal","renewal_seconds":3600}
Mai 19 18:37:30 cp2 vault-kubernetes-kms[3537120]: {"level":"info","timestamp":"2026-05-19T18:37:30.325+0200","caller":"vault/lease.go:83","message":"successfully refreshed token"}
Mai 19 18:38:30 cp2 vault-kubernetes-kms[3537120]: {"level":"error","timestamp":"2026-05-19T18:38:30.313+0200","caller":"vault/lease.go:25","message":"failed to lookup token, performing new authentication","error":"Error making API request.\n\nURL: GET https://vault.int.example.com:8200/v1/auth/token/lookup-self\nCode: 403. Errors:\n\n* 2 errors occurred:\n\t* permission denied\n\t* invalid token\n\n","stacktrace":"github.com/FalcoSuessgott/vault-kubernetes-kms/pkg/vault.(*Client).LeaseRefresher\n\t/home/ebnnfs03/austermuehle/src/github/FalcoSuessgott/vault-kubernetes-kms/pkg/vault/lease.go:25\ngithub.com/FalcoSuessgott/vault-kubernetes-kms/cmd.NewPlugin.func1\n\t/home/ebnnfs03/austermuehle/src/github/FalcoSuessgott/vault-kubernetes-kms/cmd/plugin.go:214"}
Mai 19 18:38:30 cp2 vault-kubernetes-kms[3537120]: {"level":"info","timestamp":"2026-05-19T18:38:30.332+0200","caller":"vault/lease.go:30","message":"successfully re-authenticated"}
```

Closes #304.